### PR TITLE
Add Vagrantfile to remove friction for newcomers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 /wstub/debug
 /wstub/release
 /.vscode
+/.vagrant
 
 # los exe de PMODEW sí los queremos
 !/pmwlite/*.[Ee][Xx][Ee]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ En 2015, MikeDX, antiguo miembro de FastTrak, anunció que había retomado el c�
 
 ## Cómo compilar DIV
 
+**Nota**: Alternativamente al proceso explicado a continuación, puedes [compilar DIV usando Vagrant](https://github.com/vii1/DIV/wiki/Compilar-con-Vagrant).
+
 ### Requisitos previos
 * Sistema operativo **Linux**, **MS-DOS** o **Windows** (cualquier versión, nueva o antigua).
 * [OpenWatcom 1.9](http://www.openwatcom.org/) instalado y funcionando. Posiblemente también funcione Watcom 10 o superior, pero no lo hemos probado. OJO: necesitas instalar los compiladores para *DOS 16 bits* y *DOS 32 bits*. Actualmente hay incompatibilidades en el código con OpenWatcom 2.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,72 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/bionic64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/home/vagrant/DIV"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  config.vm.provision "shell", path: "vagrant/provision.sh"
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  #config.vm.provision "shell", inline: <<-SHELL
+  #  apt-get update
+  #  apt-get install -y curl
+  #  wget https://downloads.sourceforge.net/project/openwatcom/open-watcom-1.9/open-watcom-c-linux-1.9?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fopenwatcom%2Ffiles%2Fopen-watcom-1.9%2Fopen-watcom-c-linux-1.9%2Fdownload&ts=1602275512 
+  #SHELL
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,10 @@ Vagrant.configure("2") do |config|
   # argument is a set of non-required options.
   config.vm.synced_folder ".", "/home/vagrant/DIV"
 
+  if ENV['INSTALL_DIR']
+    config.vm.synced_folder ENV['INSTALL_DIR'], "/home/vagrant/install"
+  end
+
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:

--- a/makefile
+++ b/makefile
@@ -12,6 +12,11 @@
 ROOT=$+ $(%cwd) $-
 !else
 ROOT=$+ $(%cdrive):$(%cwd) $-
+!ifdef %USERPROFILE
+%HOME=$(%USERPROFILE)
+!else
+%HOME=$(SEP)
+!endif
 !endif
 
 #####################
@@ -24,7 +29,12 @@ CONFIG = release
 # INSTALL_DIR indica la ruta donde se instalar  DIV con ``wmake install``.
 # Recomiendo usarlo para instalar DIV dentro de una carpeta de DOSBOX.
 # Muy c¢modo para agilizar tu ciclo de modificar-compilar-depurar.
-INSTALL_DIR = $(%USERPROFILE)$(SEP)dosbox$(SEP)DIV
+# Se puede configurar con una variable de entorno.
+!ifdef %INSTALL_DIR
+INSTALL_DIR = $(%INSTALL_DIR)
+!else
+INSTALL_DIR = $(%HOME)$(SEP)dosbox$(SEP)DIV
+!endif
 
 # Originalmente DIV usaba Turbo Assembler (TASM) para compilar su c¢digo en
 # ensamblador. En este fork preferimos usar WASM, ya que TASM es privativo y
@@ -43,6 +53,9 @@ TASM_EXE = tasm32.exe
 ############################
 # FIN DE COSAS CONFIGURABLES
 ############################
+
+# Nota: definimos variables de entorno (con prefijo %) para datos que
+# necesitamos pasar a otros makefiles
 
 MAKE=$+ $(MAKE) -h $-
 %CONFIG=$(CONFIG)

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Instalamos los paquetes que necesitamos.
+sudo apt update
+sudo apt upgrade -y
+sudo apt install dosbox unzip -y
+
+# Creamos la carpeta de Watcom.
+sudo mkdir /usr/bin/watcom
+sudo chown vagrant:vagrant /usr/bin/watcom
+
+#---------------------------------------------------------------------------------------------------------------------------------
+# Esto es para Open Watcom 1.9 
+#---------------------------------------------------------------------------------------------------------------------------------
+# Instalamos
+wget 'https://downloads.sourceforge.net/project/openwatcom/open-watcom-1.9/open-watcom-c-linux-1.9' -O 'open-watcom-1.9'
+unzip -o 'open-watcom-1.9' -d /usr/bin/watcom
+rm 'open-watcom-1.9'
+
+#---------------------------------------------------------------------------------------------------------------------------------
+# Esto es para Open Watcom 2.0
+#---------------------------------------------------------------------------------------------------------------------------------
+#wget 'https://github.com/open-watcom/open-watcom-v2/releases/download/Current-build/open-watcom-2_0-c-linux-x64' -O 'open-watcom-2.0'
+#unzip open-watcom-2.0 -d /usr/bin/watcom
+
+echo '#!/bin/sh
+echo Open Watcom Build Environment
+export PATH=/usr/bin/watcom/binl:$PATH
+#export INCLUDE=/usr/bin/watcom/lh:$INCLUDE
+export INCLUDE=/usr/bin/watcom/h:$INCLUDE
+export WATCOM=/usr/bin/watcom
+export EDPATH=/usr/bin/watcom/eddat
+export WIPFC=/usr/bin/watcom/wipfc' > /usr/bin/watcom/owsetenv.sh
+
+# Le damos permisos de ejecución.
+# Por lo visto esto sólo está en OW2.0
+#chmod +x /usr/bin/watcom/binl64/*
+chmod +x /usr/bin/watcom/binl/*
+chmod +x /usr/bin/watcom/owsetenv.sh
+
+# Register Open Watcom Environment
+echo 'source /usr/bin/watcom/owsetenv.sh' >> .bashrc
+source /usr/bin/watcom/owsetenv.sh
+
+# Creamos la carpeta de DOSBOX que se comenta en el makefile.
+mkdir dosbox

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -5,15 +5,15 @@ sudo apt upgrade -y
 sudo apt install dosbox unzip -y
 
 # Creamos la carpeta de Watcom.
-sudo mkdir /usr/bin/watcom
+[ ! -d /usr/bin/watcom ] && sudo mkdir /usr/bin/watcom
 sudo chown vagrant:vagrant /usr/bin/watcom
 
 #---------------------------------------------------------------------------------------------------------------------------------
 # Esto es para Open Watcom 1.9 
 #---------------------------------------------------------------------------------------------------------------------------------
 # Instalamos
-wget 'https://downloads.sourceforge.net/project/openwatcom/open-watcom-1.9/open-watcom-c-linux-1.9' -O 'open-watcom-1.9'
-unzip -o 'open-watcom-1.9' -d /usr/bin/watcom
+wget --show-progress=off 'https://downloads.sourceforge.net/project/openwatcom/open-watcom-1.9/open-watcom-c-linux-1.9' -O 'open-watcom-1.9'
+unzip -q -o 'open-watcom-1.9' -d /usr/bin/watcom
 rm 'open-watcom-1.9'
 
 #---------------------------------------------------------------------------------------------------------------------------------
@@ -24,7 +24,7 @@ rm 'open-watcom-1.9'
 
 echo '#!/bin/sh
 echo Open Watcom Build Environment
-export PATH=/usr/bin/watcom/binl:$PATH
+export PATH=/usr/bin/watcom/binl:/usr/bin/watcom/binw:$PATH
 #export INCLUDE=/usr/bin/watcom/lh:$INCLUDE
 export INCLUDE=/usr/bin/watcom/h:$INCLUDE
 export WATCOM=/usr/bin/watcom
@@ -38,7 +38,7 @@ chmod +x /usr/bin/watcom/binl/*
 chmod +x /usr/bin/watcom/owsetenv.sh
 
 # Register Open Watcom Environment
-echo 'source /usr/bin/watcom/owsetenv.sh' >> .bashrc
+fgrep -q owsetenv .bashrc || ( echo 'source /usr/bin/watcom/owsetenv.sh' >> .bashrc )
 source /usr/bin/watcom/owsetenv.sh
 
 # Creamos la carpeta de DOSBOX que se comenta en el makefile.

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -41,5 +41,9 @@ chmod +x /usr/bin/watcom/owsetenv.sh
 fgrep -q owsetenv .bashrc || ( echo 'source /usr/bin/watcom/owsetenv.sh' >> .bashrc )
 source /usr/bin/watcom/owsetenv.sh
 
-# Creamos la carpeta de DOSBOX que se comenta en el makefile.
-mkdir dosbox
+# Configuramos INSTALL_DIR
+fgrep -q INSTALL_DIR .bashrc || ( echo 'export INSTALL_DIR=$HOME/install' >> .bashrc )
+export INSTALL_DIR=$HOME/install
+
+# Creamos la carpeta de instalación si no existe
+[ ! -d $INSTALL_DIR ] && mkdir $INSTALL_DIR


### PR DESCRIPTION
Adds `Vagrantfile` and `vagrant/provision.sh` to remove friction for newcomers. 

Now, anyone that wants to compile DIV just needs to install Vagrant (and Virtual box) and run the following commands on the project root directory:

```sh
vagrant up
vagrant ssh
```

After this you'll be in a VM running ubuntu/bionic (focal doesn't work as expected) with the environment properly configured and ready to call `wmake`.

P.S.: The project folder is shared inside the VM as `DIV`.