### PR TITLE
feat: add _no_safe_exit to compiler options

### DIFF
--- a/src/div/divc.cpp
+++ b/src/div/divc.cpp
@@ -678,6 +678,7 @@ int comprueba_id;
 int comprueba_null;
 int hacer_strfix;
 int optimizar;
+int safe_exit;
 
 //อออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออ
 
@@ -1066,6 +1067,12 @@ void compilar(void) {
   #ifdef SHARE
   mem[0]+=1024;
   #endif
+
+  // A๑adimos el flag que permite al int้rprete
+  // ignorarr alt_x y ctrl_esc
+  if (!safe_exit) {
+    mem[0]+=256;
+  }
 
   if (program_type==1) if ((f=fopen("install\\setup.ovl","wb"))!=NULL) {
     fwrite(div_stub,1,602,f);
@@ -3155,6 +3162,7 @@ void sintactico (void) {
   comprueba_null=1;
   hacer_strfix=1;
   optimizar=1;
+  safe_exit=1;
 
   if (pieza==p_compiler_options) {
     lexico();
@@ -3217,6 +3225,10 @@ void sintactico (void) {
           case 11: // _no_null_check
             lexico();
             comprueba_null=0;
+            break;
+          case 12: // _no_safe_exit
+            lexico();
+            safe_exit=0;
             break;
           default:
             c_error(0,138);

--- a/src/div32run/i.cpp
+++ b/src/div32run/i.cpp
@@ -51,6 +51,7 @@ int dll_loaded=0;
 
 int trace_program=0;
 int ignore_errors=0;
+int safe_exit=1;
 
 int old_dump_type;
 int old_restore_type;
@@ -481,7 +482,11 @@ extern int alt_x;
 void interprete (void)
 {
   inicializacion();
-  while (procesos && !(kbdFLAGS[_ESC] && kbdFLAGS[_L_CTRL]) && !alt_x) {
+  while (procesos) {
+    if (safe_exit && ((kbdFLAGS[_ESC] && kbdFLAGS[_L_CTRL]) || alt_x))
+    {
+      break;
+    }
     error_vpe=0;
     frame_start();
     #ifdef DEBUG
@@ -1349,6 +1354,7 @@ void main(int argc,char * argv[]) {
         free(ptr);
 
         if ((mem[0]&128)==128) { trace_program=1; mem[0]-=128; }
+        if ((mem[0]&256)==256) { safe_exit=0; mem[0]-=256; }
         if ((mem[0]&512)==512) { ignore_errors=1; mem[0]-=512; }
         demo=0;
         if ((mem[0]&1024)==1024) {

--- a/system/ltobj.def
+++ b/system/ltobj.def
@@ -78,6 +78,7 @@ const _no_optimization=8
 const _no_range_check=9
 const _no_id_check=10
 const _no_null_check=11
+const _no_safe_exit=12
 
 const seek_set=0
 const seek_cur=1


### PR DESCRIPTION
Añade la opción `_no_safe_exit` a `compiler_options`.