### PR TITLE
feat: new_map centers automatically control point on negative coords

### DIFF
--- a/src/div32run/f.cpp
+++ b/src/div32run/f.cpp
@@ -596,7 +596,17 @@ void new_map(void) {
 
   if (ancho<1 || alto<1 || ancho>32768 || alto>32768) { e(153); return; }
   if (color<0 || color>255) { e(154); return; }
-  if (cx<0 || cy<0 || cx>=ancho || cy>=alto) { e(155); return; }
+  if (cx>=ancho || cy>=alto) { e(155); return; }
+
+  // Si alguna de las coordenadas del punto de control son negativas, calculamos
+  // el punto medio automáticamente.
+  if (cx<0) {
+    cx = ancho >> 1; 
+  } 
+
+  if (cy<0) {
+    cy = alto >> 1;
+  }
 
   if ((ptr=(byte *)malloc(1330+64+4+ancho*alto))!=NULL) {
     ptr+=1330; // fix load_map/unload_map


### PR DESCRIPTION
Un pequeño programilla para probar que funciona la feature:

```
program feat_new_map_center;
private
    int cx, cy;
begin
    graph = new_map(32, 32, -1, -1, 0);
    get_point(file, graph, 0, offset cx, offset cy);
    assert(cx == 16, "Punto de control inicial en el centro");
    assert(cy == 16, "Punto de control inicial en el centro");
    exit("Ok", 0);
end

function assert(condition, message)
begin
  if (!condition)
    exit(message, 1);
  end
  return(0);
end
```